### PR TITLE
Fix KB initialization.

### DIFF
--- a/kabob-build/src/main/clojure/edu/ucdenver/ccp/kabob/build/input_kb.clj
+++ b/kabob-build/src/main/clojure/edu/ucdenver/ccp/kabob/build/input_kb.clj
@@ -1,7 +1,7 @@
 
 (ns edu.ucdenver.ccp.kabob.build.input-kb
   (:require [edu.ucdenver.ccp.kr.kb
-             :refer [connection]]
+             :refer [connection kb]]
             [edu.ucdenver.ccp.kr.rdf
              :refer [register-namespaces synch-ns-mappings]]
             [edu.ucdenver.ccp.kr.sesame.kb
@@ -20,6 +20,6 @@
             *repository-name* (:repo-name args)
             *username* (:username args)
             *password* (:password args)]
-    (initialize-kb HTTPRepository)))
+    (initialize-kb (kb HTTPRepository))))
 
 (def source-kb open-kb)


### PR DESCRIPTION
This addresses a bug introduced in the previous commit that refactored the KB initialization.  To perform the initialization a KB *instance* is required, as returned by `edu.ucdenver.kr.kb/kb`.

Before this change I was unable to run rules against a store (the store could not be opened).  With this change in place, the rules run successfully.
