### PR TITLE
develop.bio labels

### DIFF
--- a/kabob-build/src/main/resources/edu/ucdenver/ccp/kabob/build/rules/bio_labels/genes.clj
+++ b/kabob-build/src/main/resources/edu/ucdenver/ccp/kabob/build/rules/bio_labels/genes.clj
@@ -1,0 +1,44 @@
+
+{:name "gene-labels-EntrezGene"
+
+ ;; The query pattern used to retrieve the data that will be used to construct
+ ;; the new triples.
+ :body
+ '(;; field value that contains the identifier
+   (_/gene_id_field kiao/hasTemplate iaoeg/EntrezGeneInfoFileData_geneIDDataField1)
+   (_/gene_id_field rdf/type kiao/FieldValue)
+   ;; the file record in which the field value appeared (record has-part
+   ;; field-value)
+   (_/record rdf/type iaoeg/EntrezGeneInfoFileData)
+   (_/record obo/BFO_0000051 _/gene_id_field)
+   ;; the record will also have fields for the symbol
+   (_/record obo/BFO_0000051 _/eg_symbol_field)
+   (_/eg_symbol_field kiao/hasTemplate iaoeg/EntrezGeneInfoFileData_symbolDataField1)
+   (_/eg_symbol_field obo/IAO_0000219 ?/eg_symbol)
+   ;; ICE that denotes a subclass of DNA (gene).
+   (_/gene_id_field obo/IAO_0000219 _/ice)
+   (_/ice kiao/denotesSubClassOf obo/SO_0000352)
+   (_/ice obo/IAO_0000219 ?/bio))
+
+ ;; The form of the new triples that will be constructed.
+ :head
+ '((?/bio rdfs/label ?/eg_symbol))
+
+ ;; In this case no `:reify` entry is required, since all of the data required
+ ;; to form the new triples already exist.
+
+ :options
+ {:magic-prefixes
+  [;; AllegroGraph processing directives; http://franz.com/agraph/support/documentation/current/sparql-reference.html#header2-138
+
+   ;; Note: DO NOT set the clause reorderer to `identity`.  The default
+   ;; `statistical` reorderer produces much more efficient results (as of this
+   ;; writing, a small number of minutes for `statistical` compared to over an
+   ;; hour (incomplete, terminated) for `identity`).
+
+   ;; AllegroGraph should use "chunk at a time" processing.
+   ;; This reduces memory consumption at the cost of query
+   ;; execution time.  Given that the BIO entity set is
+   ;; potentially quite large and that this is not a realtime
+   ;; operation, this is not an unreasonable trade-off.
+   ["franzOption_chunkProcessingAllowed" "franz:yes"]]}}

--- a/kabob-build/src/main/resources/edu/ucdenver/ccp/kabob/build/rules/bio_labels/proteins.clj
+++ b/kabob-build/src/main/resources/edu/ucdenver/ccp/kabob/build/rules/bio_labels/proteins.clj
@@ -1,5 +1,5 @@
 
-{:name "protein-labels-UniProt"
+{:name "protein-labels-UniProt-SwissProt"
 
  ;; The query pattern used to retrieve the data that will be used to construct
  ;; the new triples.
@@ -19,21 +19,58 @@
    (_/record obo/BFO_0000051 _/typeRecordField)
    (_/typeRecordField kiao/hasTemplate iaouniprot/ProteinSchema1)
    (_/typeRecordField rdf/type iaouniprot/Protein)
-   ;; This record will also contain the recommended name of the protein.
-   (_/typeRecordField obo/BFO_0000051 _/recommendedNameRecord)
-   (_/recommendedNameRecord kiao/hasTemplate iaouniprot/RecommendedNameSchema1)
-   (_/recommendedNameRecord rdf/type iaouniprot/RecommendedName)
-   ;; The recommended name field is an evidenced string.
-   (_/recommendedNameRecord obo/BFO_0000051 _/evidencedStringRecord)
-   (_/evidencedStringRecord kiao/hasTemplate iaouniprot/EvidencedStringSchema1)
-   (_/evidencedStringRecord rdf/type iaouniprot/EvidencedString)
-   ;; The value of the evidenced string is what we want as the protein name.
-   (_/evidencedStringRecord obo/BFO_0000051 _/evidencedStringValue)
-   (_/evidencedStringValue obo/IAO_0000219 ?/proteinName))
+   ;; This record will also contain the unique name of the protein.
+   (_/record obo/BFO_0000051 _/nameRecord)
+   (_/nameRecord kiao/hasTemplate iaouniprot/UniProtFileRecord_nameDataField1)
+   (_/nameRecord obo/IAO_0000219 ?/proteinName))
 
  ;; The form of the new triples that will be constructed.
  :head
- '((?/bio rdf/label ?/proteinName))
+ '((?/bio rdfs/label ?/proteinName))
+
+ ;; In this case no `:reify` entry is required, since all of the data required
+ ;; to form the new triples already exist.
+
+ :options
+ {:magic-prefixes
+  [;; AllegroGraph processing directives; http://franz.com/agraph/support/documentation/current/sparql-reference.html#header2-138
+
+   ;; Note: DO NOT set the clause reorderer to `identity`.  The default
+   ;; `statistical` reorderer produces much more efficient results (as of this
+   ;; writing, a small number of minutes for `statistical` compared to over an
+   ;; hour (incomplete, terminated) for `identity`).
+
+   ;; AllegroGraph should use "chunk at a time" processing.
+   ;; This reduces memory consumption at the cost of query
+   ;; execution time.  Given that the BIO entity set is
+   ;; potentially quite large and that this is not a realtime
+   ;; operation, this is not an unreasonable trade-off.
+   ["franzOption_chunkProcessingAllowed" "franz:yes"]]}}
+
+{:name "protein-labels-UniProt-Trembl"
+
+ ;; The query pattern used to retrieve the data that will be used to construct
+ ;; the new triples.
+ :body
+ '(;; UniProt ICE that denotes a BIO entity that is a protein.
+   (?/ice kiao/denotesSubClassOf obo/CHEBI_36080)
+   (?/ice obo/IAO_0000219 ?/bio)
+   (?/bio rdfs/subClassOf obo/CHEBI_36080)
+   ;; Find the source field from which the ID was constructed.
+   (_/accessionRecordField obo/IAO_0000219 ?/ice)
+   (_/accessionRecordField kiao/hasTemplate iaouniprot/SparseUniProtFileRecord_accessionDataField1)
+   (_/accessionRecordField rdf/type kiao/FieldValue)
+   ;; Link the source field to the record in which it was found.
+   (_/record rdf/type iaouniprot/SparseUniProtFileRecord)
+   (_/record obo/BFO_0000051 _/accessionRecordField)
+   ;; This record will also contain the unique name of the protein.
+   (_/record obo/BFO_0000051 _/nameRecord)
+   (_/nameRecord kiao/hasTemplate iaouniprot/SparseUniProtFileRecord_nameDataField1)
+   (_/nameRecord obo/IAO_0000219 ?/proteinName))
+
+ ;; The form of the new triples that will be constructed.
+ :head
+ '((?/bio rdfs/label ?/proteinName))
 
  ;; In this case no `:reify` entry is required, since all of the data required
  ;; to form the new triples already exist.

--- a/kabob-build/src/main/resources/edu/ucdenver/ccp/kabob/build/rules/bio_labels/proteins.clj
+++ b/kabob-build/src/main/resources/edu/ucdenver/ccp/kabob/build/rules/bio_labels/proteins.clj
@@ -1,0 +1,55 @@
+
+{:name "protein-labels-UniProt"
+
+ ;; The query pattern used to retrieve the data that will be used to construct
+ ;; the new triples.
+ :body
+ '(;; UniProt ICE that denotes a BIO entity that is a protein.
+   (?/ice kiao/denotesSubClassOf obo/CHEBI_36080)
+   (?/ice obo/IAO_0000219 ?/bio)
+   (?/bio rdfs/subClassOf obo/CHEBI_36080)
+   ;; Find the source field from which the ID was constructed.
+   (_/accessionRecordField obo/IAO_0000219 ?/ice)
+   (_/accessionRecordField kiao/hasTemplate iaouniprot/UniProtFileRecord_accessionDataField1)
+   (_/accessionRecordField rdf/type kiao/FieldValue)
+   ;; Link the source field to the record in which it was found.
+   (_/record rdf/type iaouniprot/UniProtFileRecord)
+   (_/record obo/BFO_0000051 _/accessionRecordField)
+   ;; Necessarily a record that describes a protein.
+   (_/record obo/BFO_0000051 _/typeRecordField)
+   (_/typeRecordField kiao/hasTemplate iaouniprot/ProteinSchema1)
+   (_/typeRecordField rdf/type iaouniprot/Protein)
+   ;; This record will also contain the recommended name of the protein.
+   (_/typeRecordField obo/BFO_0000051 _/recommendedNameRecord)
+   (_/recommendedNameRecord kiao/hasTemplate iaouniprot/RecommendedNameSchema1)
+   (_/recommendedNameRecord rdf/type iaouniprot/RecommendedName)
+   ;; The recommended name field is an evidenced string.
+   (_/recommendedNameRecord obo/BFO_0000051 _/evidencedStringRecord)
+   (_/evidencedStringRecord kiao/hasTemplate iaouniprot/EvidencedStringSchema1)
+   (_/evidencedStringRecord rdf/type iaouniprot/EvidencedString)
+   ;; The value of the evidenced string is what we want as the protein name.
+   (_/evidencedStringRecord obo/BFO_0000051 _/evidencedStringValue)
+   (_/evidencedStringValue obo/IAO_0000219 ?/proteinName))
+
+ ;; The form of the new triples that will be constructed.
+ :head
+ '((?/bio rdf/label ?/proteinName))
+
+ ;; In this case no `:reify` entry is required, since all of the data required
+ ;; to form the new triples already exist.
+
+ :options
+ {:magic-prefixes
+  [;; AllegroGraph processing directives; http://franz.com/agraph/support/documentation/current/sparql-reference.html#header2-138
+
+   ;; Note: DO NOT set the clause reorderer to `identity`.  The default
+   ;; `statistical` reorderer produces much more efficient results (as of this
+   ;; writing, a small number of minutes for `statistical` compared to over an
+   ;; hour (incomplete, terminated) for `identity`).
+
+   ;; AllegroGraph should use "chunk at a time" processing.
+   ;; This reduces memory consumption at the cost of query
+   ;; execution time.  Given that the BIO entity set is
+   ;; potentially quite large and that this is not a realtime
+   ;; operation, this is not an unreasonable trade-off.
+   ["franzOption_chunkProcessingAllowed" "franz:yes"]]}}


### PR DESCRIPTION
Attach labels to the BIO entities for proteins and genes.  There are a couple of points worth noting:

* no special effort is made to ensure that one, and only one, label is attached to the entity; it is unclear whether this is actually desirable in the long term (we may, for example, decide to use a different property to describe the "preferred" name).
* The labels are simply the ID, without any indication of its origin; this should be changed in (the near) future so that a user/developer won't have to guess at the original source of the label.

To address either of these points, further changes would be needed to the way that the rules are interpreted.  We'd need for the rules engine to handle more SPARQL operators (i.e the changes that Elizabeth has made for the Reactome rules), a pure-SPARQL rule body, or more flexible `:head` management.  For example, to attach one and only one rule, one option would be to `MINUS` triples that already have a label; decorating the label with the source name or description would require the ability to `BIND` in body pattern, which is not currently possible.

This rules should, however, satisfy the requirements for the VEGF demo, and so I think they're a useful interim solution.  Counter-{arguments, proposals} are welcome.