### PR TITLE
Prevent incorrect generation of redundant HGNC bio-entities

### DIFF
--- a/kabob-build/src/main/resources/edu/ucdenver/ccp/kabob/build/rules/id_mapping/skos_exact/hgnc_download_file_rules.clj
+++ b/kabob-build/src/main/resources/edu/ucdenver/ccp/kabob/build/rules/id_mapping/skos_exact/hgnc_download_file_rules.clj
@@ -1,4 +1,17 @@
-
+`{:name "hgnc-symbol-hgnc-id-exact-mapping"
+  :description "HGNC has two unique identifiers for each record,
+  an approved gene symbol and a unique integer identifer. In the id-typing
+  rules we declare that both types kiao/denotesSubClassOf obo/SO_0000352. In
+  doing so, the bioentity generation machinery will create bio-entities for each
+  type. This particular rule is required to ensure that only a single bio-entity
+  gets created for each HGNC record. If the HGNC approved symbol and integer
+  identifier for a given HGNC record are not declared as skos/exactMatch then
+  two distinct bio-entities will be erroneously generated instead of just one."
+  :head ((?/hgncSymbolIce skos/exactMatch ?/hgncIntegerIdIce))
+  :body
+  (~@(kabob/rtv _/record
+        iaohgnc/HgncDownloadFileData_hgncGeneSymbolDataField1 ?/hgncSymbolIce
+        iaohgnc/HgncDownloadFileData_hgncIDDataField1  ?/hgncIntegerIdIce))}
 
 `{:name "hgnc-symbol-eg-id-exact-mapping"
   :head ((?/hgncSymbolIce skos/exactMatch ?/egIce))
@@ -39,4 +52,3 @@
 
 
 
-       

--- a/kabob-build/src/main/resources/edu/ucdenver/ccp/kabob/build/rules/temp/drugbank/drugbank_rules.clj
+++ b/kabob-build/src/main/resources/edu/ucdenver/ccp/kabob/build/rules/temp/drugbank/drugbank_rules.clj
@@ -76,6 +76,9 @@
     (_/polypeptide_record kiao/hasTemplate iaodrugbank/PolypeptideSchema1)
     (_/polypeptide_record obo/BFO_0000051 _/polypeptide_id_field)
     (_/polypeptide_id_field obo/IAO_0000219 _/protein_ice_id)
+    ;; ensure that the identifier is a protein identifier
+    ;; the polypeptide id sometimes contains gene ids (e.g. HGNC ids)
+    (_/protein_ice_id kiao/denotesSubClassOf obo/CHEBI_36080)
     (_/protein_ice_id obo/IAO_0000219 ?/target_bioentity)
   )
 


### PR DESCRIPTION
HGNC has two unique identifiers for each record, an approved gene symbol and a unique integer identifier. In the id-typing rules we declare that both identifier types are kiao/denotesSubClassOf obo/SO_0000352. We currently neglect to include a rule that declares the gene symbol and unique integer identifiers for a give gene as skos:exactMatch. Because of this missing rule, the bioentity generation machinery creates two distinct bio-entities for each HGNC record (one for each identifier type). 

Commit d0cca3d adds the skos:exactMatch rule to link the gene symbol and unique integer identifiers for a given HGNC gene.

Commit 81cb21d is a work-around for this bug in the DrugBank drug-to-protein-target rule that prevents gene identifiers from being referenced as the target of a drug-target interaction. This bug was discovered while developing the DrugBank drug-to-protein-target rule.

These commits are in response to https://trello.com/c/c7nmwN5c