### PR TITLE
Updated ccp namespace

### DIFF
--- a/kabob-core/src/main/clojure/edu/ucdenver/ccp/kabob/namespace.clj
+++ b/kabob-core/src/main/clojure/edu/ucdenver/ccp/kabob/namespace.clj
@@ -28,7 +28,7 @@
 
 
        ;;("iao" "http://purl.obolibrary.org/obo/")
-       ("ccp_obo_ext" "http://ccp.ucdenver.edu/obo/ext/")
+       ("ccp" "http://ccp.ucdenver.edu/obo/ext/")
        ("kiao" "http://kabob.ucdenver.edu/iao/")
        ("kabob" "http://kabob.ucdenver.edu/")
        ("kbio" "http://kabob.ucdenver.edu/bio/")


### PR DESCRIPTION
Changed the name of the ccp namespace key from "ccp_obo_ext" to simply "ccp"