### PR TITLE
add rules to extract basic entities in Reactome from BioPAX to ICE

### DIFF
--- a/resources/rules/_0_pre_identifier_merge/_1_post_ice_rdf_load/step_c_other_ice_gen/step_ca_reactome_add_base_types_as_ice/add_biochemical_reaction_records_and_reactome_ids_from_human_reactome_to_ice_step_a.clj
+++ b/resources/rules/_0_pre_identifier_merge/_1_post_ice_rdf_load/step_c_other_ice_gen/step_ca_reactome_add_base_types_as_ice/add_biochemical_reaction_records_and_reactome_ids_from_human_reactome_to_ice_step_a.clj
@@ -1,0 +1,44 @@
+{:description "This rule finds any biochemical reaction record described in Reactome and traces out its link to a unification xref to extract the biochemical reaction's Reactome ID.",
+ :name "add_biochemical_reaction_records_and_reactome_ids_from_human_reactome_to_ice_step_a",
+ :reify ([?/record_set {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome v60 record set"), :prefix "R_"}]
+         [?/download {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome v60 download"), :prefix "D_"}]
+         [?/bcr_record {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome biochemical reaction record" ?/bcr), :prefix "R_"}]
+         [?/xref_record {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome unification xref record" ?/xref), :prefix "R_"}]
+         [?/xref_id_field {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome unification xref record id field" ?/react_id), :prefix "F_"}]
+         [?/xref_db_field {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome unification xref record db field" ?/react_db), :prefix "F_"}]),
+ :head ((?/record_set rdf/type ccp/IAO_EXT_00000012)
+        (?/record_set obo/IAO_0000142 ?/download)
+        (?/download rdfs/label "http://www.reactome.org/pages/download-data/biopax/Homo_sapiens.owl")
+        (?/record_set obo/BFO_0000051 ?/bcr_record)
+        (?/bcr obo/IAO_0000142 ?/bcr_record)
+        (?/bcr_record rdf/type ccp/IAO_EXT_0001554)
+        (?/bcr_record obo/BFO_0000051 ?/xref_record)
+        (?/xref_record rdf/type ccp/IAO_EXT_0001588)
+        (?/xref_record rdf/type ccp/IAO_EXT_0001572)
+        (?/xref_record obo/BFO_0000051 ?/xref_db_field)
+        (?/xref_record obo/BFO_0000051 ?/xref_id_field)
+        (?/xref_db_field rdf/type ccp/IAO_EXT_0001519)
+        (?/xref_db_field rdfs/label "Reactome")
+        (?/xref_id_field rdf/type ccp/IAO_EXT_0001520)
+        (?/xref_id_field rdf/type ccp/IAO_EXT_0001517)
+        (?/xref_id_field rdfs/label ?/clean_react_id)),
+ :sparql-string "#ekw
+PREFIX franzOption_chunkProcessingAllowed: <franz:yes>
+PREFIX franzOption_clauseReorderer: <franz:identity>
+PREFIX obo: <http://purl.obolibrary.org/obo/>
+PREFIX ccp: <http://ccp.ucdenver.edu/obo/ext/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX bp: <http://www.biopax.org/release/biopax-level3.owl#>
+PREFIX bp3: <http://www.reactome.org/biopax/63/48887#>
+SELECT ?bcr ?xref ?react_db ?react_id ?clean_react_id
+WHERE {
+?bcr rdf:type bp:BiochemicalReaction .
+?bcr bp:xref ?xref .
+?xref rdf:type bp:UnificationXref .
+?xref bp:db ?react_db .
+filter (regex (str (?react_db), \"^Reactome$\")) .
+?xref bp:id ?react_id .
+bind (str (?react_id) as ?clean_react_id) .
+}",
+ :options {:magic-prefixes [["franzOption_logQuery" "franz:yes"] ["franzOption_clauseReorderer" "franz:identity"]]}}

--- a/resources/rules/_0_pre_identifier_merge/_1_post_ice_rdf_load/step_c_other_ice_gen/step_ca_reactome_add_base_types_as_ice/add_catalysis_records_from_human_reactome_to_ice_step_a.clj
+++ b/resources/rules/_0_pre_identifier_merge/_1_post_ice_rdf_load/step_c_other_ice_gen/step_ca_reactome_add_base_types_as_ice/add_catalysis_records_from_human_reactome_to_ice_step_a.clj
@@ -1,0 +1,24 @@
+{:description "This rule finds any catalysis record described in Reactome; no Reactome IDs are available.",
+ :name "add_catalysis_records_from_human_reactome_to_ice_step_a",
+ :reify ([?/record_set {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome v60 record set"), :prefix "R_"}]
+         [?/download {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome v60 download"), :prefix "D_"}]
+         [?/catal_record {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome catalysis record" ?/catal), :prefix "R_"}] ),
+ :head ((?/record_set rdf/type ccp/IAO_EXT_00000012)
+        (?/record_set obo/IAO_0000142 ?/download)
+        (?/download rdfs/label "http://www.reactome.org/pages/download-data/biopax/Homo_sapiens.owl")
+        (?/record_set obo/BFO_0000051 ?/catal_record)
+        (?/catal obo/IAO_0000142 ?/catal_record)
+        (?/catal_record rdf/type ccp/IAO_EXT_0001574)),
+ :sparql-string "#ekw
+PREFIX franzOption_chunkProcessingAllowed: <franz:yes>
+PREFIX franzOption_clauseReorderer: <franz:identity>
+PREFIX obo: <http://purl.obolibrary.org/obo/>
+PREFIX ccp: <http://ccp.ucdenver.edu/obo/ext/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX bp: <http://www.biopax.org/release/biopax-level3.owl#>
+PREFIX bp3: <http://www.reactome.org/biopax/63/48887#>
+SELECT ?catal WHERE {
+?catal rdf:type bp:Catalysis . 
+}",
+ :options {:magic-prefixes [["franzOption_logQuery" "franz:yes"] ["franzOption_clauseReorderer" "franz:identity"]]}}

--- a/resources/rules/_0_pre_identifier_merge/_1_post_ice_rdf_load/step_c_other_ice_gen/step_ca_reactome_add_base_types_as_ice/add_complex_records_and_reactome_ids_from_human_reactome_to_ice_step_a.clj
+++ b/resources/rules/_0_pre_identifier_merge/_1_post_ice_rdf_load/step_c_other_ice_gen/step_ca_reactome_add_base_types_as_ice/add_complex_records_and_reactome_ids_from_human_reactome_to_ice_step_a.clj
@@ -1,0 +1,46 @@
+{:description "This rule finds any complex record described in Reactome and traces out its link to a unification xref to extract the complex's Reactome ID.",
+ :name "add_complex_records_and_reactome_ids_from_human_reactome_to_ice_step_a",
+ :reify ([?/record_set {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome v60 record set"), :prefix "R_"}]
+         [?/download {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome v60 download"), :prefix "D_"}]
+         [?/compl_record {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome complex record" ?/compl), :prefix "R_"}]
+         [?/xref_record {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome unification xref record" ?/xref), :prefix "R_"}]
+         [?/xref_id_field {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome unification xref record id field" ?/react_id), :prefix "F_"}]
+         [?/xref_db_field {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome unification xref record db field" ?/react_db), :prefix "F_"}]),
+ :head ((?/record_set rdf/type ccp/IAO_EXT_00000012)
+        (?/record_set obo/IAO_0000142 ?/download)
+        (?/download rdfs/label "http://www.reactome.org/pages/download-data/biopax/Homo_sapiens.owl")
+        (?/record_set obo/BFO_0000051 ?/compl_record)
+        (?/compl obo/IAO_0000142 ?/compl_record)
+        (?/compl_record rdf/type ccp/IAO_EXT_0001516)
+        (?/compl_record obo/BFO_0000051 ?/xref_record)
+        (?/xref_record rdf/type ccp/IAO_EXT_0001588)
+        (?/xref_record rdf/type ccp/IAO_EXT_0001572)
+        (?/xref_record obo/BFO_0000051 ?/xref_db_field)
+        (?/xref_record obo/BFO_0000051 ?/xref_id_field)
+        (?/xref_db_field rdf/type ccp/IAO_EXT_0001519)
+        (?/xref_db_field rdfs/label "Reactome")
+        (?/xref_id_field rdf/type ccp/IAO_EXT_0001520)
+        (?/xref_id_field rdf/type ccp/IAO_EXT_0001517)
+        (?/xref_id_field rdfs/label ?/clean_react_id)),
+ :sparql-string "#ekw
+PREFIX franzOption_chunkProcessingAllowed: <franz:yes>
+PREFIX franzOption_clauseReorderer: <franz:identity>
+PREFIX obo: <http://purl.obolibrary.org/obo/>
+PREFIX ccp: <http://ccp.ucdenver.edu/obo/ext/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX bp: <http://www.biopax.org/release/biopax-level3.owl#>
+PREFIX bp3: <http://www.reactome.org/biopax/64/48887#> 
+PREFIX kice: <http://ccp.ucdenver.edu/kabob/ice/>
+PREFIX kbio: <http://ccp.ucdenver.edu/kabob/bio/>
+SELECT ?compl ?xref ?react_db ?react_id ?clean_react_id
+WHERE {
+?compl rdf:type bp:Complex .
+?compl bp:xref ?xref .
+?xref rdf:type bp:UnificationXref .
+?xref bp:db ?react_db .
+filter (regex (str (?react_db), \"^Reactome$\")) .
+?xref bp:id ?react_id .
+bind (str (?react_id) as ?clean_react_id) .
+}",
+ :options {:magic-prefixes [["franzOption_logQuery" "franz:yes"] ["franzOption_clauseReorderer" "franz:identity"]]}}

--- a/resources/rules/_0_pre_identifier_merge/_1_post_ice_rdf_load/step_c_other_ice_gen/step_ca_reactome_add_base_types_as_ice/add_control_records_and_reactome_ids_from_human_reactome_to_ice_step_a.clj
+++ b/resources/rules/_0_pre_identifier_merge/_1_post_ice_rdf_load/step_c_other_ice_gen/step_ca_reactome_add_base_types_as_ice/add_control_records_and_reactome_ids_from_human_reactome_to_ice_step_a.clj
@@ -1,0 +1,44 @@
+{:description "This rule finds any control record described in Reactome and traces out its link to a unification xref to extract the control's Reactome ID.",
+ :name "add_control_records_and_reactome_ids_from_human_reactome_to_ice_step_a",
+ :reify ([?/record_set {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome v60 record set"), :prefix "R_"}]
+         [?/download {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome v60 download"), :prefix "D_"}]
+         [?/contr_record {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome control record" ?/contr), :prefix "R_"}]
+         [?/xref_record {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome unification xref record" ?/xref), :prefix "R_"}]
+         [?/xref_id_field {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome unification xref record id field" ?/react_id), :prefix "F_"}]
+         [?/xref_db_field {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome unification xref record db field" ?/react_db), :prefix "F_"}]),
+ :head ((?/record_set rdf/type ccp/IAO_EXT_00000012)
+        (?/record_set obo/IAO_0000142 ?/download)
+        (?/download rdfs/label "http://www.reactome.org/pages/download-data/biopax/Homo_sapiens.owl")
+        (?/record_set obo/BFO_0000051 ?/contr_record)
+        (?/contr obo/IAO_0000142 ?/contr_record)
+        (?/contr_record rdf/type ccp/IAO_EXT_0001564)
+        (?/contr_record obo/BFO_0000051 ?/xref_record)
+        (?/xref_record rdf/type ccp/IAO_EXT_0001588)
+        (?/xref_record rdf/type ccp/IAO_EXT_0001572)
+        (?/xref_record obo/BFO_0000051 ?/xref_db_field)
+        (?/xref_record obo/BFO_0000051 ?/xref_id_field)
+        (?/xref_db_field rdf/type ccp/IAO_EXT_0001519)
+        (?/xref_db_field rdfs/label "Reactome")
+        (?/xref_id_field rdf/type ccp/IAO_EXT_0001520)
+        (?/xref_id_field rdf/type ccp/IAO_EXT_0001517)
+        (?/xref_id_field rdfs/label ?/clean_react_id)),
+ :sparql-string "#ekw
+PREFIX franzOption_chunkProcessingAllowed: <franz:yes>
+PREFIX franzOption_clauseReorderer: <franz:identity>
+PREFIX obo: <http://purl.obolibrary.org/obo/>
+PREFIX ccp: <http://ccp.ucdenver.edu/obo/ext/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX bp: <http://www.biopax.org/release/biopax-level3.owl#>
+PREFIX bp3: <http://www.reactome.org/biopax/63/48887#>
+SELECT ?contr ?xref ?react_db ?react_id ?clean_react_id
+WHERE {
+?contr rdf:type bp:Control .
+?contr bp:xref ?xref .
+?xref rdf:type bp:UnificationXref .
+?xref bp:db ?react_db .
+filter (regex (str (?react_db), \"^Reactome$\")) .
+?xref bp:id ?react_id .
+bind (str (?react_id) as ?clean_react_id) .
+}",
+ :options {:magic-prefixes [["franzOption_logQuery" "franz:yes"] ["franzOption_clauseReorderer" "franz:identity"]]}}

--- a/resources/rules/_0_pre_identifier_merge/_1_post_ice_rdf_load/step_c_other_ice_gen/step_ca_reactome_add_base_types_as_ice/add_degradation_records_and_reactome_ids_from_human_reactome_to_ice_step_a.clj
+++ b/resources/rules/_0_pre_identifier_merge/_1_post_ice_rdf_load/step_c_other_ice_gen/step_ca_reactome_add_base_types_as_ice/add_degradation_records_and_reactome_ids_from_human_reactome_to_ice_step_a.clj
@@ -1,0 +1,44 @@
+{:description "This rule finds any degradation record described in Reactome and traces out its link to a unification xref to extract the degradation's Reactome ID.",
+ :name "add_degradation_records_and_reactome_ids_from_human_reactome_to_ice_step_a",
+ :reify ([?/record_set {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome v60 record set"), :prefix "R_"}]
+         [?/download {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome v60 download"), :prefix "D_"}]
+         [?/degr_record {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome degradation record" ?/degr), :prefix "R_"}]
+         [?/xref_record {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome unification xref record" ?/xref), :prefix "R_"}]
+         [?/xref_id_field {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome unification xref record id field" ?/react_id), :prefix "F_"}]
+         [?/xref_db_field {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome unification xref record db field" ?/react_db), :prefix "F_"}]),
+ :head ((?/record_set rdf/type ccp/IAO_EXT_00000012)
+        (?/record_set obo/IAO_0000142 ?/download)
+        (?/download rdfs/label "http://www.reactome.org/pages/download-data/biopax/Homo_sapiens.owl")
+        (?/record_set obo/BFO_0000051 ?/degr_record)
+        (?/degr obo/IAO_0000142 ?/degr_record)
+        (?/degr_record rdf/type ccp/IAO_EXT_0001585)
+        (?/degr_record obo/BFO_0000051 ?/xref_record)
+        (?/xref_record rdf/type ccp/IAO_EXT_0001588)
+        (?/xref_record rdf/type ccp/IAO_EXT_0001572)
+        (?/xref_record obo/BFO_0000051 ?/xref_db_field)
+        (?/xref_record obo/BFO_0000051 ?/xref_id_field)
+        (?/xref_db_field rdf/type ccp/IAO_EXT_0001519)
+        (?/xref_db_field rdfs/label "Reactome")
+        (?/xref_id_field rdf/type ccp/IAO_EXT_0001520)
+        (?/xref_id_field rdf/type ccp/IAO_EXT_0001517)
+        (?/xref_id_field rdfs/label ?/clean_react_id)),
+ :sparql-string "#ekw
+PREFIX franzOption_chunkProcessingAllowed: <franz:yes>
+PREFIX franzOption_clauseReorderer: <franz:identity>
+PREFIX obo: <http://purl.obolibrary.org/obo/>
+PREFIX ccp: <http://ccp.ucdenver.edu/obo/ext/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX bp: <http://www.biopax.org/release/biopax-level3.owl#>
+PREFIX bp3: <http://www.reactome.org/biopax/63/48887#>
+SELECT ?degr ?xref ?react_db ?react_id ?clean_react_id
+WHERE {
+?degr rdf:type bp:Degradation .
+?degr bp:xref ?xref .
+?xref rdf:type bp:UnificationXref .
+?xref bp:db ?react_db .
+filter (regex (str (?react_db), \"^Reactome$\")) .
+?xref bp:id ?react_id .
+bind (str (?react_id) as ?clean_react_id) .
+}",
+ :options {:magic-prefixes [["franzOption_logQuery" "franz:yes"] ["franzOption_clauseReorderer" "franz:identity"]]}}

--- a/resources/rules/_0_pre_identifier_merge/_1_post_ice_rdf_load/step_c_other_ice_gen/step_ca_reactome_add_base_types_as_ice/add_dna_records_and_reactome_ids_from_human_reactome_to_ice_step_a.clj
+++ b/resources/rules/_0_pre_identifier_merge/_1_post_ice_rdf_load/step_c_other_ice_gen/step_ca_reactome_add_base_types_as_ice/add_dna_records_and_reactome_ids_from_human_reactome_to_ice_step_a.clj
@@ -1,0 +1,46 @@
+{:description "This rule finds any DNA record described in Reactome and traces out its link to a unification xref to extract the DNA's Reactome ID.",
+ :name "add_dna_records_and_reactome_ids_from_human_reactome_to_ice_step_a",
+ :reify ([?/record_set {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome v60 record set"), :prefix "R_"}]
+         [?/download {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome v60 download"), :prefix "D_"}]
+         [?/dna_record {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome dna record" ?/dna), :prefix "R_"}]
+         [?/xref_record {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome unification xref record" ?/xref), :prefix "R_"}]
+         [?/xref_id_field {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome unification xref record id field" ?/react_id), :prefix "F_"}]
+         [?/xref_db_field {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome unification xref record db field" ?/react_db), :prefix "F_"}]),
+ :head ((?/record_set rdf/type ccp/IAO_EXT_00000012)
+        (?/record_set obo/IAO_0000142 ?/download)
+        (?/download rdfs/label "http://www.reactome.org/pages/download-data/biopax/Homo_sapiens.owl")
+        (?/record_set obo/BFO_0000051 ?/dna_record)
+        (?/dna obo/IAO_0000142 ?/dna_record)
+        (?/dna_record rdf/type ccp/IAO_EXT_0001556)
+        (?/dna_record obo/BFO_0000051 ?/xref_record)
+        (?/xref_record rdf/type ccp/IAO_EXT_0001588)
+        (?/xref_record rdf/type ccp/IAO_EXT_0001572)
+        (?/xref_record obo/BFO_0000051 ?/xref_db_field)
+        (?/xref_record obo/BFO_0000051 ?/xref_id_field)
+        (?/xref_db_field rdf/type ccp/IAO_EXT_0001519)
+        (?/xref_db_field rdfs/label "Reactome")
+        (?/xref_id_field rdf/type ccp/IAO_EXT_0001520)
+        (?/xref_id_field rdf/type ccp/IAO_EXT_0001517)
+        (?/xref_id_field rdfs/label ?/clean_react_id)),
+ :sparql-string "#ekw
+PREFIX franzOption_chunkProcessingAllowed: <franz:yes>
+PREFIX franzOption_clauseReorderer: <franz:identity>
+PREFIX obo: <http://purl.obolibrary.org/obo/>
+PREFIX ccp: <http://ccp.ucdenver.edu/obo/ext/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX bp: <http://www.biopax.org/release/biopax-level3.owl#>
+PREFIX bp3: <http://www.reactome.org/biopax/64/48887#>
+PREFIX kice: <http://ccp.ucdenver.edu/kabob/ice/>
+PREFIX kbio: <http://ccp.ucdenver.edu/kabob/bio/>
+SELECT ?dna ?xref ?react_db ?react_id ?clean_react_id 
+WHERE {
+?dna rdf:type bp:Dna .
+?dna bp:xref ?xref .
+?xref rdf:type bp:UnificationXref .
+?xref bp:db ?react_db .
+filter (regex (str (?react_db), \"^Reactome$\")) .
+?xref bp:id ?react_id .
+bind (str (?react_id) as ?clean_react_id) .
+}",
+ :options {:magic-prefixes [["franzOption_logQuery" "franz:yes"] ["franzOption_clauseReorderer" "franz:identity"]]}}

--- a/resources/rules/_0_pre_identifier_merge/_1_post_ice_rdf_load/step_c_other_ice_gen/step_ca_reactome_add_base_types_as_ice/add_pathway_records_and_reactome_ids_from_human_reactome_to_ice_step_a.clj
+++ b/resources/rules/_0_pre_identifier_merge/_1_post_ice_rdf_load/step_c_other_ice_gen/step_ca_reactome_add_base_types_as_ice/add_pathway_records_and_reactome_ids_from_human_reactome_to_ice_step_a.clj
@@ -1,0 +1,44 @@
+{:description "This rule finds any pathway record described in Reactome and traces out its link to a unification xref to extract the pathway's Reactome ID.",
+ :name "add_pathway_records_and_reactome_ids_from_human_reactome_to_ice_step_a",
+ :reify ([?/record_set {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome v60 record set"), :prefix "R_"}]
+         [?/download {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome v60 download"), :prefix "D_"}]
+         [?/pw_record {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome pathway record" ?/pw), :prefix "R_"}]
+         [?/xref_record {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome unification xref record" ?/xref), :prefix "R_"}]
+         [?/xref_id_field {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome unification xref record id field" ?/react_id), :prefix "F_"}]
+         [?/xref_db_field {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome unification xref record db field" ?/react_db), :prefix "F_"}]),
+ :head ((?/record_set rdf/type ccp/IAO_EXT_00000012)
+        (?/record_set obo/IAO_0000142 ?/download)
+        (?/download rdfs/label "http://www.reactome.org/pages/download-data/biopax/Homo_sapiens.owl")
+        (?/record_set obo/BFO_0000051 ?/pw_record)
+        (?/pw obo/IAO_0000142 ?/pw_record)
+        (?/pw_record rdf/type ccp/IAO_EXT_0001553)
+        (?/pw_record obo/BFO_0000051 ?/xref_record)
+        (?/xref_record rdf/type ccp/IAO_EXT_0001588)
+        (?/xref_record rdf/type ccp/IAO_EXT_0001572)
+        (?/xref_record obo/BFO_0000051 ?/xref_db_field)
+        (?/xref_record obo/BFO_0000051 ?/xref_id_field)
+        (?/xref_db_field rdf/type ccp/IAO_EXT_0001519)
+        (?/xref_db_field rdfs/label "Reactome")
+        (?/xref_id_field rdf/type ccp/IAO_EXT_0001520)
+        (?/xref_id_field rdf/type ccp/IAO_EXT_0001517)
+        (?/xref_id_field rdfs/label ?/clean_react_id)),
+ :sparql-string "#ekw
+PREFIX franzOption_chunkProcessingAllowed: <franz:yes>
+PREFIX franzOption_clauseReorderer: <franz:identity>
+PREFIX obo: <http://purl.obolibrary.org/obo/>
+PREFIX ccp: <http://ccp.ucdenver.edu/obo/ext/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX bp: <http://www.biopax.org/release/biopax-level3.owl#>
+PREFIX bp3: <http://www.reactome.org/biopax/63/48887#>
+SELECT ?pw ?xref ?react_db ?react_id ?clean_react_id
+WHERE {
+?pw rdf:type bp:Pathway .
+?pw bp:xref ?xref .
+?xref rdf:type bp:UnificationXref .
+?xref bp:db ?react_db .
+filter (regex (str (?react_db), \"^Reactome$\")) .
+?xref bp:id ?react_id .
+bind (str (?react_id) as ?clean_react_id) .
+}",
+ :options {:magic-prefixes [["franzOption_logQuery" "franz:yes"] ["franzOption_clauseReorderer" "franz:identity"]]}}

--- a/resources/rules/_0_pre_identifier_merge/_1_post_ice_rdf_load/step_c_other_ice_gen/step_ca_reactome_add_base_types_as_ice/add_pathway_step_records_from_human_reactome_to_ice_step_a.clj
+++ b/resources/rules/_0_pre_identifier_merge/_1_post_ice_rdf_load/step_c_other_ice_gen/step_ca_reactome_add_base_types_as_ice/add_pathway_step_records_from_human_reactome_to_ice_step_a.clj
@@ -1,0 +1,25 @@
+{:description "This rule finds any pathway step record described in Reactome.",
+ :name "add_pathway_step_records_from_human_reactome_to_ice_step_a",
+ :reify ([?/record_set {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome v60 record set"), :prefix "R_"}]
+         [?/download {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome v60 download"), :prefix "D_"}]
+         [?/pws_record {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome pathway step record" ?/pws), :prefix "R_"}]),
+ :head ((?/record_set rdf/type ccp/IAO_EXT_00000012)
+        (?/record_set obo/IAO_0000142 ?/download)
+        (?/download rdfs/label "http://www.reactome.org/pages/download-data/biopax/Homo_sapiens.owl")
+        (?/record_set obo/BFO_0000051 ?/pws_record)
+        (?/pws obo/IAO_0000142 ?/pws_record)
+        (?/pws_record rdf/type ccp/IAO_EXT_0001573)),
+ :sparql-string "#ekw
+PREFIX franzOption_chunkProcessingAllowed: <franz:yes>
+PREFIX franzOption_clauseReorderer: <franz:identity>
+PREFIX obo: <http://purl.obolibrary.org/obo/>
+PREFIX ccp: <http://ccp.ucdenver.edu/obo/ext/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX bp: <http://www.biopax.org/release/biopax-level3.owl#>
+PREFIX bp3: <http://www.reactome.org/biopax/63/48887#>
+SELECT ?pws 
+WHERE {
+?pws rdf:type bp:PathwayStep .
+}",
+ :options {:magic-prefixes [["franzOption_logQuery" "franz:yes"] ["franzOption_clauseReorderer" "franz:identity"]]}}

--- a/resources/rules/_0_pre_identifier_merge/_1_post_ice_rdf_load/step_c_other_ice_gen/step_ca_reactome_add_base_types_as_ice/add_physical_entity_records_and_reactome_ids_from_human_reactome_to_ice_step_a.clj
+++ b/resources/rules/_0_pre_identifier_merge/_1_post_ice_rdf_load/step_c_other_ice_gen/step_ca_reactome_add_base_types_as_ice/add_physical_entity_records_and_reactome_ids_from_human_reactome_to_ice_step_a.clj
@@ -1,0 +1,46 @@
+{:description "This rule finds any physical entity record described in Reactome and traces out its link to a unification xref to extract the physical entity's Reactome ID.",
+ :name "add_physical_entity_records_and_reactome_ids_from_human_reactome_to_ice_step_a",
+ :reify ([?/record_set {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome v60 record set"), :prefix "R_"}]
+         [?/download {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome v60 download"), :prefix "D_"}]
+         [?/phent_record {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome physical entity record" ?/phent), :prefix "R_"}]
+         [?/xref_record {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome unification xref record" ?/xref), :prefix "R_"}]
+         [?/xref_id_field {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome unification xref record id field" ?/react_id), :prefix "F_"}]
+         [?/xref_db_field {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome unification xref record db field" ?/react_db), :prefix "F_"}]),
+ :head ((?/record_set rdf/type ccp/IAO_EXT_00000012)
+        (?/record_set obo/IAO_0000142 ?/download)
+        (?/download rdfs/label "http://www.reactome.org/pages/download-data/biopax/Homo_sapiens.owl")
+        (?/record_set obo/BFO_0000051 ?/phent_record)
+        (?/phent obo/IAO_0000142 ?/phent_record)
+        (?/phent_record rdf/type ccp/IAO_EXT_0001515)
+        (?/phent_record obo/BFO_0000051 ?/xref_record)
+        (?/xref_record rdf/type ccp/IAO_EXT_0001588)
+        (?/xref_record rdf/type ccp/IAO_EXT_0001572)
+        (?/xref_record obo/BFO_0000051 ?/xref_db_field)
+        (?/xref_record obo/BFO_0000051 ?/xref_id_field)
+        (?/xref_db_field rdf/type ccp/IAO_EXT_0001519)
+        (?/xref_db_field rdfs/label "Reactome")
+        (?/xref_id_field rdf/type ccp/IAO_EXT_0001520)
+        (?/xref_id_field rdf/type ccp/IAO_EXT_0001517)
+        (?/xref_id_field rdfs/label ?/clean_react_id)),
+ :sparql-string "#ekw
+PREFIX franzOption_chunkProcessingAllowed: <franz:yes>
+PREFIX franzOption_clauseReorderer: <franz:identity>
+PREFIX obo: <http://purl.obolibrary.org/obo/>
+PREFIX ccp: <http://ccp.ucdenver.edu/obo/ext/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX bp: <http://www.biopax.org/release/biopax-level3.owl#>
+PREFIX bp3: <http://www.reactome.org/biopax/64/48887#>
+PREFIX kice: <http://ccp.ucdenver.edu/kabob/ice/>
+PREFIX kbio: <http://ccp.ucdenver.edu/kabob/bio/>
+SELECT ?phent ?xref ?react_id ?react_db ?clean_react_id
+WHERE {
+?phent rdf:type bp:PhysicalEntity .
+?phent bp:xref ?xref .
+?xref rdf:type bp:UnificationXref .
+?xref bp:db ?react_db .
+filter (regex (str (?react_db), \"^Reactome$\")) .
+?xref bp:id ?react_id .
+bind (str (?react_id) as ?clean_react_id) .
+}",
+ :options {:magic-prefixes [["franzOption_logQuery" "franz:yes"] ["franzOption_clauseReorderer" "franz:identity"]]}}

--- a/resources/rules/_0_pre_identifier_merge/_1_post_ice_rdf_load/step_c_other_ice_gen/step_ca_reactome_add_base_types_as_ice/add_protein_records_and_reactome_ids_from_human_reactome_to_ice_step_a.clj
+++ b/resources/rules/_0_pre_identifier_merge/_1_post_ice_rdf_load/step_c_other_ice_gen/step_ca_reactome_add_base_types_as_ice/add_protein_records_and_reactome_ids_from_human_reactome_to_ice_step_a.clj
@@ -1,0 +1,45 @@
+{:description "This rule finds any protein record described in Reactome and traces out its link to a unification xref to extract the protein's Reactome ID.  Several Reactome protein records may correspond to the same UniProt ID, but the different records represent the protein in different modified forms or in different cellular compartments.",
+ :name "add_protein_records_and_reactome_ids_from_human_reactome_to_ice_step_a",
+ :reify ([?/record_set {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome v60 record set"), :prefix "R_"}]
+         [?/download {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome v60 download"), :prefix "D_"}]
+         [?/prot_record {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome protein record" ?/prot), :prefix "R_"}]
+         [?/xref_record {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome unification xref record" ?/xref), :prefix "R_"}]
+         [?/xref_id_field {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome unification xref record id field" ?/react_id), :prefix "F_"}]
+         [?/xref_db_field {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome unification xref record db field" ?/react_db), :prefix "F_"}]),
+ :head ((?/record_set rdf/type ccp/IAO_EXT_00000012)
+        (?/record_set obo/IAO_0000142 ?/download)
+        (?/download rdfs/label "http://www.reactome.org/pages/download-data/biopax/Homo_sapiens.owl")
+        (?/record_set obo/BFO_0000051 ?/prot_record)
+        (?/prot obo/IAO_0000142 ?/prot_record)
+        (?/prot_record rdf/type ccp/IAO_EXT_0001513)
+        (?/prot_record obo/BFO_0000051 ?/xref_record)
+        (?/xref_record rdf/type ccp/IAO_EXT_0001588)
+        (?/xref_record rdf/type ccp/IAO_EXT_0001572)
+        (?/xref_record obo/BFO_0000051 ?/xref_db_field)
+        (?/xref_record obo/BFO_0000051 ?/xref_id_field)
+        (?/xref_db_field rdf/type ccp/IAO_EXT_0001519)
+        (?/xref_db_field rdfs/label "Reactome")
+        (?/xref_id_field rdf/type ccp/IAO_EXT_0001520)
+        (?/xref_id_field rdf/type ccp/IAO_EXT_0001517)
+        (?/xref_id_field rdfs/label ?/clean_react_id)),
+ :sparql-string "#ekw 
+PREFIX franzOption_chunkProcessingAllowed: <franz:yes>
+PREFIX franzOption_clauseReorderer: <franz:identity>
+PREFIX obo: <http://purl.obolibrary.org/obo/>
+PREFIX ccp: <http://ccp.ucdenver.edu/obo/ext/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX bp: <http://www.biopax.org/release/biopax-level3.owl#>
+PREFIX bp3: <http://www.reactome.org/biopax/64/48887#>
+PREFIX kice: <http://ccp.ucdenver.edu/kabob/ice/>
+PREFIX kbio: <http://ccp.ucdenver.edu/kabob/bio/>
+SELECT ?prot ?xref ?react_db ?react_id ?clean_react_id 
+WHERE {
+?prot rdf:type bp:Protein .
+?prot bp:xref ?xref .
+?xref rdf:type bp:UnificationXref .
+?xref bp:db ?react_db .
+filter (regex (str (?react_db), \"^Reactome$\")) .
+?xref bp:id ?react_id .\n bind (str (?react_id) as ?clean_react_id) .
+}",
+ :options {:magic-prefixes [["franzOption_logQuery" "franz:yes"] ["franzOption_clauseReorderer" "franz:identity"]]}}

--- a/resources/rules/_0_pre_identifier_merge/_1_post_ice_rdf_load/step_c_other_ice_gen/step_ca_reactome_add_base_types_as_ice/add_rna_records_and_reactome_ids_from_human_reactome_to_ice_step_a.clj
+++ b/resources/rules/_0_pre_identifier_merge/_1_post_ice_rdf_load/step_c_other_ice_gen/step_ca_reactome_add_base_types_as_ice/add_rna_records_and_reactome_ids_from_human_reactome_to_ice_step_a.clj
@@ -1,0 +1,46 @@
+{:description "This rule finds any RNA record described in Reactome and traces out its link to a unification xref to extract the RNA's Reactome ID.",
+ :name "add_rna_records_and_reactome_ids_from_human_reactome_to_ice_step_a",
+ :reify ([?/record_set {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome v60 record set"), :prefix "R_"}]
+         [?/download {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome v60 download"), :prefix "D_"}]
+         [?/rna_record {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome rna record" ?/rna), :prefix "R_"}]
+         [?/xref_record {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome unification xref record" ?/xref), :prefix "R_"}]
+         [?/xref_id_field {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome unification xref record id field" ?/react_id), :prefix "F_"}]
+         [?/xref_db_field {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome unification xref record db field" ?/react_db), :prefix "F_"}]),
+ :head ((?/record_set rdf/type ccp/IAO_EXT_00000012)
+        (?/record_set obo/IAO_0000142 ?/download)
+        (?/download rdfs/label "http://www.reactome.org/pages/download-data/biopax/Homo_sapiens.owl")
+        (?/record_set obo/BFO_0000051 ?/rna_record)
+        (?/rna obo/IAO_0000142 ?/rna_record)
+        (?/rna_record rdf/type ccp/IAO_EXT_0001558)
+        (?/rna_record obo/BFO_0000051 ?/xref_record)
+        (?/xref_record rdf/type ccp/IAO_EXT_0001588)
+        (?/xref_record rdf/type ccp/IAO_EXT_0001572)
+        (?/xref_record obo/BFO_0000051 ?/xref_db_field)
+        (?/xref_record obo/BFO_0000051 ?/xref_id_field)
+        (?/xref_db_field rdf/type ccp/IAO_EXT_0001519)
+        (?/xref_db_field rdfs/label "Reactome")
+        (?/xref_id_field rdf/type ccp/IAO_EXT_0001520)
+        (?/xref_id_field rdf/type ccp/IAO_EXT_0001517)
+        (?/xref_id_field rdfs/label ?/clean_react_id)),
+ :sparql-string "#ekw
+PREFIX franzOption_chunkProcessingAllowed: <franz:yes>
+PREFIX franzOption_clauseReorderer: <franz:identity>
+PREFIX obo: <http://purl.obolibrary.org/obo/>
+PREFIX ccp: <http://ccp.ucdenver.edu/obo/ext/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX bp: <http://www.biopax.org/release/biopax-level3.owl#>
+PREFIX bp3: <http://www.reactome.org/biopax/64/48887#>
+PREFIX kice: <http://ccp.ucdenver.edu/kabob/ice/>
+PREFIX kbio: <http://ccp.ucdenver.edu/kabob/bio/>
+SELECT ?rna ?xref ?react_db ?react_id ?clean_react_id
+WHERE {
+?rna rdf:type bp:Rna .
+?rna bp:xref ?xref .
+?xref rdf:type bp:UnificationXref .
+?xref bp:db ?react_db .
+filter (regex (str (?react_db), \"^Reactome$\")) .
+?xref bp:id ?react_id .
+bind (str (?react_id) as ?clean_react_id) .
+}",
+ :options {:magic-prefixes [["franzOption_logQuery" "franz:yes"] ["franzOption_clauseReorderer" "franz:identity"]]}}

--- a/resources/rules/_0_pre_identifier_merge/_1_post_ice_rdf_load/step_c_other_ice_gen/step_ca_reactome_add_base_types_as_ice/add_small_molecule_records_and_reactome_ids_from_human_reactome_to_ice_step_a.clj
+++ b/resources/rules/_0_pre_identifier_merge/_1_post_ice_rdf_load/step_c_other_ice_gen/step_ca_reactome_add_base_types_as_ice/add_small_molecule_records_and_reactome_ids_from_human_reactome_to_ice_step_a.clj
@@ -1,0 +1,46 @@
+{:description "This rule finds any small molecule record described in Reactome and traces out its link to a unification xref to extract the small molecule's Reactome ID.  Different records represent the small molecule in different cellular compartments.",
+ :name "add_small_molecule_records_and_reactome_ids_from_human_reactome_to_ice_step_a",
+ :reify ([?/record_set {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome v60 record set"), :prefix "R_"}]
+         [?/download {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome v60 download"), :prefix "D_"}]
+         [?/smmol_record {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome small molecule record" ?/smmol), :prefix "R_"}]
+         [?/xref_record {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome unification xref record" ?/xref), :prefix "R_"}]
+         [?/xref_id_field {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome unification xref record id field" ?/react_id), :prefix "F_"}]
+         [?/xref_db_field {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome unification xref record db field" ?/react_db), :prefix "F_"}]),
+ :head ((?/record_set rdf/type ccp/IAO_EXT_00000012)
+        (?/record_set obo/IAO_0000142 ?/download)
+        (?/download rdfs/label "http://www.reactome.org/pages/download-data/biopax/Homo_sapiens.owl")
+        (?/record_set obo/BFO_0000051 ?/smmol_record)
+        (?/smmol obo/IAO_0000142 ?/smmol_record)
+        (?/smmol_record rdf/type ccp/IAO_EXT_0001514)
+        (?/smmol_record obo/BFO_0000051 ?/xref_record)
+        (?/xref_record rdf/type ccp/IAO_EXT_0001588)
+        (?/xref_record rdf/type ccp/IAO_EXT_0001572)
+        (?/xref_record obo/BFO_0000051 ?/xref_db_field)
+        (?/xref_record obo/BFO_0000051 ?/xref_id_field)
+        (?/xref_db_field rdf/type ccp/IAO_EXT_0001519)
+        (?/xref_db_field rdfs/label "Reactome")
+        (?/xref_id_field rdf/type ccp/IAO_EXT_0001520)
+        (?/xref_id_field rdf/type ccp/IAO_EXT_0001517)
+        (?/xref_id_field rdfs/label ?/clean_react_id)),
+ :sparql-string "#ekw
+PREFIX franzOption_chunkProcessingAllowed: <franz:yes>
+PREFIX franzOption_clauseReorderer: <franz:identity>
+PREFIX obo: <http://purl.obolibrary.org/obo/>
+PREFIX ccp: <http://ccp.ucdenver.edu/obo/ext/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX bp: <http://www.biopax.org/release/biopax-level3.owl#>
+PREFIX bp3: <http://www.reactome.org/biopax/64/48887#>
+PREFIX kice: <http://ccp.ucdenver.edu/kabob/ice/>
+PREFIX kbio: <http://ccp.ucdenver.edu/kabob/bio/>
+SELECT ?smmol ?xref ?react_id ?react_db ?clean_react_id
+WHERE {
+?smmol rdf:type bp:SmallMolecule .
+?smmol bp:xref ?xref .
+?xref rdf:type bp:UnificationXref .
+?xref bp:db ?react_db .
+filter (regex (str (?react_db), \"^Reactome$\")) .
+?xref bp:id ?react_id .
+bind (str (?react_id) as ?clean_react_id) .
+}",
+ :options {:magic-prefixes [["franzOption_logQuery" "franz:yes"] ["franzOption_clauseReorderer" "franz:identity"]]}}

--- a/resources/rules/_0_pre_identifier_merge/_1_post_ice_rdf_load/step_c_other_ice_gen/step_ca_reactome_add_base_types_as_ice/add_template_reaction_records_and_reactome_ids_from_human_reactome_to_ice_step_a.clj
+++ b/resources/rules/_0_pre_identifier_merge/_1_post_ice_rdf_load/step_c_other_ice_gen/step_ca_reactome_add_base_types_as_ice/add_template_reaction_records_and_reactome_ids_from_human_reactome_to_ice_step_a.clj
@@ -1,0 +1,43 @@
+{:description "This rule finds any template reaction record described in Reactome and traces out its link to a unification xref to extract the template reaction's Reactome ID.",
+ :name "add_template_reaction_records_and_reactome_ids_from_human_reactome_to_ice_step_a",
+ :reify ([?/record_set {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome v60 record set"), :prefix "R_"}]
+         [?/download {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome v60 download"), :prefix "D_"}]
+         [?/bcr_record {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome template reaction record" ?/bcr), :prefix "R_"}]
+         [?/xref_record {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome unification xref record" ?/xref), :prefix "R_"}]
+         [?/xref_id_field {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome unification xref record id field" ?/react_id), :prefix "F_"}]
+         [?/xref_db_field {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome unification xref record db field" ?/react_db), :prefix "F_"}]),
+ :head ((?/record_set rdf/type ccp/IAO_EXT_00000012)
+        (?/record_set obo/IAO_0000142 ?/download)
+        (?/download rdfs/label "http://www.reactome.org/pages/download-data/biopax/Homo_sapiens.owl")
+        (?/record_set obo/BFO_0000051 ?/bcr_record)
+        (?/bcr obo/IAO_0000142 ?/bcr_record)
+        (?/bcr_record rdf/type ccp/IAO_EXT_0001580)
+        (?/bcr_record obo/BFO_0000051 ?/xref_record)
+        (?/xref_record rdf/type ccp/IAO_EXT_0001588)
+        (?/xref_record rdf/type ccp/IAO_EXT_0001572)
+        (?/xref_record obo/BFO_0000051 ?/xref_db_field)
+        (?/xref_record obo/BFO_0000051 ?/xref_id_field)
+        (?/xref_db_field rdf/type ccp/IAO_EXT_0001519)
+        (?/xref_db_field rdfs/label "Reactome")
+        (?/xref_id_field rdf/type ccp/IAO_EXT_0001520)
+        (?/xref_id_field rdf/type ccp/IAO_EXT_0001517)
+        (?/xref_id_field rdfs/label ?/clean_react_id)),
+ :sparql-string "#ekw
+PREFIX franzOption_chunkProcessingAllowed: <franz:yes>
+PREFIX franzOption_clauseReorderer: <franz:identity>
+PREFIX obo: <http://purl.obolibrary.org/obo/>
+PREFIX ccp: <http://ccp.ucdenver.edu/obo/ext/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX bp: <http://www.biopax.org/release/biopax-level3.owl#>
+PREFIX bp3: <http://www.reactome.org/biopax/63/48887#>
+SELECT ?bcr ?xref ?react_db ?react_id ?clean_react_id
+WHERE {
+?bcr rdf:type bp:TemplateReaction .
+?bcr bp:xref ?xref .
+?xref rdf:type bp:UnificationXref .
+?xref bp:db ?react_db .
+filter (regex (str (?react_db), \"^Reactome$\")) .
+?xref bp:id ?react_id .
+bind (str (?react_id) as ?clean_react_id) .\n}",
+ :options {:magic-prefixes [["franzOption_logQuery" "franz:yes"] ["franzOption_clauseReorderer" "franz:identity"]]}}

--- a/resources/rules/_0_pre_identifier_merge/_1_post_ice_rdf_load/step_c_other_ice_gen/step_ca_reactome_add_base_types_as_ice/add_template_reaction_regulation_records_and_reactome_ids_from_human_reactome_to_ice_step_a.clj
+++ b/resources/rules/_0_pre_identifier_merge/_1_post_ice_rdf_load/step_c_other_ice_gen/step_ca_reactome_add_base_types_as_ice/add_template_reaction_regulation_records_and_reactome_ids_from_human_reactome_to_ice_step_a.clj
@@ -1,0 +1,44 @@
+{:description "This rule finds any template reaction regulation record described in Reactome and traces out its link to a unification xref to extract the template reaction regulation's Reactome ID.",
+ :name "add_template_reaction_regulation_records_and_reactome_ids_from_human_reactome_to_ice_step_a",
+ :reify ([?/record_set {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome v60 record set"), :prefix "R_"}]
+         [?/download {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome v60 download"), :prefix "D_"}]
+         [?/bcr_record {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome template reaction regulation record" ?/bcr), :prefix "R_"}]
+         [?/xref_record {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome unification xref record" ?/xref), :prefix "R_"}]
+         [?/xref_id_field {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome unification xref record id field" ?/react_id), :prefix "F_"}]
+         [?/xref_db_field {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome unification xref record db field" ?/react_db), :prefix "F_"}]),
+ :head ((?/record_set rdf/type ccp/IAO_EXT_00000012)
+        (?/record_set obo/IAO_0000142 ?/download)
+        (?/download rdfs/label "http://www.reactome.org/pages/download-data/biopax/Homo_sapiens.owl")
+        (?/record_set obo/BFO_0000051 ?/bcr_record)
+        (?/bcr obo/IAO_0000142 ?/bcr_record)
+        (?/bcr_record rdf/type ccp/IAO_EXT_0001581)
+        (?/bcr_record obo/BFO_0000051 ?/xref_record)
+        (?/xref_record rdf/type ccp/IAO_EXT_0001588)
+        (?/xref_record rdf/type ccp/IAO_EXT_0001572)
+        (?/xref_record obo/BFO_0000051 ?/xref_db_field)
+        (?/xref_record obo/BFO_0000051 ?/xref_id_field)
+        (?/xref_db_field rdf/type ccp/IAO_EXT_0001519)
+        (?/xref_db_field rdfs/label "Reactome")
+        (?/xref_id_field rdf/type ccp/IAO_EXT_0001520)
+        (?/xref_id_field rdf/type ccp/IAO_EXT_0001517)
+        (?/xref_id_field rdfs/label ?/clean_react_id)),
+ :sparql-string "#ekw
+PREFIX franzOption_chunkProcessingAllowed: <franz:yes>
+PREFIX franzOption_clauseReorderer: <franz:identity>
+PREFIX obo: <http://purl.obolibrary.org/obo/>
+PREFIX ccp: <http://ccp.ucdenver.edu/obo/ext/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX bp: <http://www.biopax.org/release/biopax-level3.owl#>
+PREFIX bp3: <http://www.reactome.org/biopax/63/48887#>
+SELECT ?bcr ?xref ?react_db ?react_id ?clean_react_id
+WHERE {
+?bcr rdf:type bp:TemplateReactionRegulation .
+?bcr bp:xref ?xref .
+?xref rdf:type bp:UnificationXref .
+?xref bp:db ?react_db .
+filter (regex (str (?react_db), \"^Reactome$\")) .
+?xref bp:id ?react_id .
+bind (str (?react_id) as ?clean_react_id) .
+}",
+ :options {:magic-prefixes [["franzOption_logQuery" "franz:yes"] ["franzOption_clauseReorderer" "franz:identity"]]}}


### PR DESCRIPTION
Add rules for parsing basic Reactome entities from BioPAX to KaBOB ICE.
Entities include
Continuants: proteins, small molecules, physical entities, dnas, rnas, and complexes
Occurrents: biochemical reactions, template reactions, degradations, pathways; controls, template reaction regulations, and pathway steps.
When these rules are working, there's a lot more ICE to generate.
Watch for the rules' returning triples with missing forward slashes (http:/ rather than http://) in the URIs of existing BioPAX entities. Here's an example of one in the first position:
http:/www.reactome.org/biopax/65/48887#TemplateReactionRegulation8 <http://pur
l.obolibrary.org/obo/IAO_0000142> <http://ccp.ucdenver.edu/kabob/ice/R_hQXlqE4km
e-3HAiVOIU_ZXgx9rU> .