### PR TITLE
add rules to extract second and third round of Reactome class fields …

### DIFF
--- a/resources/rules/_0_pre_identifier_merge/_1_post_ice_rdf_load/step_c_other_ice_gen/step_cb_add_base_type_biopax_fields_2_as_ice/add_biochemical_reaction_record_inputs_from_human_reactome_to_ice_step_f1.clj
+++ b/resources/rules/_0_pre_identifier_merge/_1_post_ice_rdf_load/step_c_other_ice_gen/step_cb_add_base_type_biopax_fields_2_as_ice/add_biochemical_reaction_record_inputs_from_human_reactome_to_ice_step_f1.clj
@@ -1,0 +1,32 @@
+`{:description "This rule finds any previously reified biochemical reaction record from Reactome and sets its input fields, where the input and output are not the same entity.",
+ :name "add_biochemical_reaction_record_inputs_from_human_reactome_to_ice_step_f1",
+ :head ((?/bcr_record obo/BFO_0000051 ?/left_participant_record)
+        (?/left_participant_record rdf/type ccp/IAO_EXT_0001549)),
+ :body "#add_biochemical_reaction_record_inputs_from_human_reactome_to_ice_step_f1.clj
+PREFIX franzOption_chunkProcessingAllowed: <franz:yes>
+PREFIX franzOption_clauseReorderer: <franz:identity>
+PREFIX obo: <http://purl.obolibrary.org/obo/>
+PREFIX ccp: <http://ccp.ucdenver.edu/obo/ext/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX bp: <http://www.biopax.org/release/biopax-level3.owl#>
+PREFIX bp3: <http://www.reactome.org/biopax/63/48887#>
+SELECT ?bcr_record ?left_participant ?left_participant_record 
+WHERE {
+?bcr rdf:type bp:BiochemicalReaction .    # a biochemical reaction
+?bcr bp:left ?left_participant .       # with a left participant 
+OPTIONAL {
+?left_participant ccp:ekws_temp_connector_relation ?left_participant_field .
+}
+FILTER (!bound (?left_participant_field)).
+GRAPH <file://add_biochemical_reaction_records_and_reactome_ids_from_human_reactome_to_ice_step_a.nt> { 
+?bcr obo:IAO_0000142 ?bcr_record .
+}
+?left_participant obo:IAO_0000142 ?left_participant_record .
+GRAPH <file://add_biochemical_reaction_record_conversion_directions_from_human_reactome_to_ice_step_c.nt> {
+?bcr_record obo:BFO_0000051 ?direction_field .
+?direction_field rdf:type ccp:IAO_EXT_0001546 .
+?direction_field rdfs:label \"LEFT-TO-RIGHT\"@en .
+}
+}"
+}

--- a/resources/rules/_0_pre_identifier_merge/_1_post_ice_rdf_load/step_c_other_ice_gen/step_cb_add_base_type_biopax_fields_2_as_ice/add_biochemical_reaction_record_outputs_from_human_reactome_to_ice_step_f2.clj
+++ b/resources/rules/_0_pre_identifier_merge/_1_post_ice_rdf_load/step_c_other_ice_gen/step_cb_add_base_type_biopax_fields_2_as_ice/add_biochemical_reaction_record_outputs_from_human_reactome_to_ice_step_f2.clj
@@ -1,0 +1,32 @@
+`{:description "This rule finds any previously reified biochemical reaction record from Reactome and sets its output fields, where the input and output are not the same entity.",
+ :name "add_biochemical_reaction_record_outputs_from_human_reactome_to_ice_step_f2",
+ :head ((?/bcr_record obo/BFO_0000051 ?/right_participant_record)
+        (?/right_participant_record rdf/type ccp/IAO_EXT_0001550)),
+ :body "#add_biochemical_reaction_record_outputs_from_human_reactome_to_ice_step_f2.clj
+PREFIX franzOption_chunkProcessingAllowed: <franz:yes>
+PREFIX franzOption_clauseReorderer: <franz:identity>
+PREFIX obo: <http://purl.obolibrary.org/obo/>
+PREFIX ccp: <http://ccp.ucdenver.edu/obo/ext/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX bp: <http://www.biopax.org/release/biopax-level3.owl#>
+PREFIX bp3: <http://www.reactome.org/biopax/63/48887#>
+SELECT  ?bcr_record ?right_participant ?right_participant_record 
+WHERE {
+?bcr rdf:type bp:BiochemicalReaction .    # a biochemical reaction
+?bcr bp:right ?right_participant .       # with a right participant 
+OPTIONAL {
+?right_participant ccp:ekws_temp_connector_relation ?right_participant_field .
+}
+FILTER (! bound (?right_participant_field)).
+GRAPH <file://add_biochemical_reaction_records_and_reactome_ids_from_human_reactome_to_ice_step_a.nt> { 
+?bcr obo:IAO_0000142 ?bcr_record .
+}
+?right_participant obo:IAO_0000142 ?right_participant_record .
+GRAPH <file://add_biochemical_reaction_record_conversion_directions_from_human_reactome_to_ice_step_c.nt> {
+?bcr_record obo:BFO_0000051 ?direction_field .
+?direction_field rdf:type ccp:IAO_EXT_0001546 .
+?direction_field rdfs:label \"LEFT-TO-RIGHT\"@en .
+}
+}"
+}

--- a/resources/rules/_0_pre_identifier_merge/_1_post_ice_rdf_load/step_c_other_ice_gen/step_cb_add_base_type_biopax_fields_2_as_ice/add_complex_record_component_stoichiometries_from_human_reactome_to_ice_step_e.clj
+++ b/resources/rules/_0_pre_identifier_merge/_1_post_ice_rdf_load/step_c_other_ice_gen/step_cb_add_base_type_biopax_fields_2_as_ice/add_complex_record_component_stoichiometries_from_human_reactome_to_ice_step_e.clj
@@ -1,0 +1,36 @@
+`{:description "This rule finds any previously reified complex record from Reactome and sets its component stoichiometry fields.",
+ :name "add_complex_record_component_stoichiometries_from_human_reactome_to_ice_step_e",
+ :reify ([?/stoichiometry_record {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome stoichiometry record" ?/stoi), :prefix "R_"}]
+         [?/coefficient_field {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome stoichiometric coefficient field" ?/stoi_coeff), :prefix "F_"}])
+  :head ((?/compl_record obo/BFO_0000051 ?/stoichiometry_record)
+        (?/stoichiometry_record rdf/type ccp/IAO_EXT_0001565) ;; Reactome component stoichiometry field type
+        (?/stoichiometry_record rdf/type ccp/IAO_EXT_0001545) ;; Reactome stoichiometry record
+         (?/stoichiometry_record obo/BFO_0000051 ?/component_record)
+         (?/component_record rdf/type ccp/IAO_EXT_0001539) ;; physical entity field value
+         (?/stoichiometry_record obo/BFO_0000051 ?/coefficient_field)
+         (?/coefficient_field rdfs/label ?/stoi_coeff)
+         (?/coefficient_field rdf/type ccp/IAO_EXT_0001540) ;; stoichimetric coefficient field type
+        
+        ),
+ :body "#add_complex_record_component_stoichiometries_from_human_reactome_to_ice_step_e.clj
+PREFIX franzOption_chunkProcessingAllowed: <franz:yes>
+PREFIX franzOption_clauseReorderer: <franz:identity>
+PREFIX obo: <http://purl.obolibrary.org/obo/>
+PREFIX ccp: <http://ccp.ucdenver.edu/obo/ext/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX bp: <http://www.biopax.org/release/biopax-level3.owl#>
+PREFIX bp3: <http://www.reactome.org/biopax/63/48887#> 
+SELECT ?compl_record ?stoi_coeff ?component_record ?component ?stoi 
+WHERE {
+?compl rdf:type bp:Complex .
+?compl bp:componentStoichiometry ?stoi .
+?stoi bp:physicalEntity ?component .
+?compl bp:component ?component .
+?stoi bp:stoichiometricCoefficient ?stoi_coeff .
+GRAPH <file://add_complex_records_and_reactome_ids_from_human_reactome_to_ice_step_a.nt> {
+?compl obo:IAO_0000142 ?compl_record .
+}
+?component obo:IAO_0000142 ?component_record .
+}"
+}

--- a/resources/rules/_0_pre_identifier_merge/_1_post_ice_rdf_load/step_c_other_ice_gen/step_cb_add_base_type_biopax_fields_3_as_ice/add_biochemical_reaction_record_input_stoichiometries_from_human_reactome_to_ice_step_g1.clj
+++ b/resources/rules/_0_pre_identifier_merge/_1_post_ice_rdf_load/step_c_other_ice_gen/step_cb_add_base_type_biopax_fields_3_as_ice/add_biochemical_reaction_record_input_stoichiometries_from_human_reactome_to_ice_step_g1.clj
@@ -1,0 +1,39 @@
+`{:description "This rule finds any previously reified biochemical reaction record from Reactome and sets its left stoichiometry fields.",
+ :name "add_biochemical_reaction_record_input_stoichiometries_from_human_reactome_to_ice_step_g1",
+ :reify ([?/stoichiometry_record {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome stoichiometry record" ?/stoi), :prefix "R_"}]
+         [?/coefficient_field {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome stoichiometric coefficient field" ?/stoi_coeff), :prefix "F_"}])
+ :head ((?/bcr_record obo/BFO_0000051 ?/stoichiometry_record)
+        (?/stoichiometry_record rdf/type ccp/IAO_EKW_002007) ;; Reactome participant stoichiometry field type
+        (?/stoichiometry_record rdf/type ccp/IAO_EXT_0001545) ;; Reactome stoichiometry record
+        (?/stoichiometry_record obo/BFO_0000051 ?/left_record)
+        (?/left_record rdf/type ccp/IAO_EXT_0001539) ;; physical entity field value
+        (?/stoichiometry_record obo/BFO_0000051 ?/coefficient_field)
+        (?/coefficient_field rdfs/label ?/stoi_coeff)
+        (?/coefficient_field rdf/type ccp/IAO_EXT_0001540) ;; stoichimetric coefficient field type        
+        ),
+ :body "#add_biochemical_reaction_record_input_stoichiometries_from_human_reactome_to_ice_step_g1.clj
+PREFIX franzOption_chunkProcessingAllowed: <franz:yes>
+PREFIX franzOption_clauseReorderer: <franz:identity>
+PREFIX obo: <http://purl.obolibrary.org/obo/>
+PREFIX ccp: <http://ccp.ucdenver.edu/obo/ext/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX bp: <http://www.biopax.org/release/biopax-level3.owl#>
+PREFIX bp3: <http://www.reactome.org/biopax/63/48887#>
+SELECT ?bcr_record ?stoi_coeff ?stoi ?left_record 
+WHERE {
+?bcr rdf:type bp:BiochemicalReaction .
+?bcr bp:participantStoichiometry ?stoi .
+?stoi bp:physicalEntity ?left .
+?bcr bp:left ?left .
+?stoi bp:stoichiometricCoefficient ?stoi_coeff .
+GRAPH <file://add_biochemical_reaction_records_and_reactome_ids_from_human_reactome_to_ice_step_a.nt> {
+?bcr obo:IAO_0000142 ?bcr_record .
+}
+?left obo:IAO_0000142 ?left_record .
+GRAPH <file://add_biochemical_reaction_record_inputs_from_human_reactome_to_ice_step_f1.nt> {
+?bcr_record obo:BFO_0000051 ?left_record .
+?left_record rdf:type ccp:IAO_EXT_0001549 .
+}
+}"
+}

--- a/resources/rules/_0_pre_identifier_merge/_1_post_ice_rdf_load/step_c_other_ice_gen/step_cb_add_base_type_biopax_fields_3_as_ice/add_biochemical_reaction_record_output_stoichiometries_from_human_reactome_to_ice_step_g2.clj
+++ b/resources/rules/_0_pre_identifier_merge/_1_post_ice_rdf_load/step_c_other_ice_gen/step_cb_add_base_type_biopax_fields_3_as_ice/add_biochemical_reaction_record_output_stoichiometries_from_human_reactome_to_ice_step_g2.clj
@@ -1,0 +1,39 @@
+`{:description "This rule finds any previously reified biochemical reaction record from Reactome and sets its right stoichiometry fields.",
+ :name "add_biochemical_reaction_record_output_stoichiometries_from_human_reactome_to_ice_step_g2",
+ :reify ([?/stoichiometry_record {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome stoichiometry record" ?/stoi), :prefix "R_"}]
+         [?/coefficient_field {:ns "http://ccp.ucdenver.edu/kabob/ice/", :ln (:sha-1 "Reactome stoichiometric coefficient field" ?/stoi_coeff), :prefix "F_"}])
+ :head ((?/bcr_record obo/BFO_0000051 ?/stoichiometry_record)
+        (?/stoichiometry_record rdf/type ccp/IAO_EKW_002007) ;; Reactome participant stoichiometry field type
+        (?/stoichiometry_record rdf/type ccp/IAO_EXT_0001545) ;; Reactome stoichiometry record
+        (?/stoichiometry_record obo/BFO_0000051 ?/right_record)
+        (?/right_record rdf/type ccp/IAO_EXT_0001539) ;; physical entity field value
+        (?/stoichiometry_record obo/BFO_0000051 ?/coefficient_field)
+        (?/coefficient_field rdfs/label ?/stoi_coeff)
+        (?/coefficient_field rdf/type ccp/IAO_EXT_0001540) ;; stoichiometric coefficient field type
+        ),
+ :body "#add_biochemical_reaction_record_output_stoichiometries_from_human_reactome_to_ice_step_g2.clj
+PREFIX franzOption_chunkProcessingAllowed: <franz:yes>
+PREFIX franzOption_clauseReorderer: <franz:identity>
+PREFIX obo: <http://purl.obolibrary.org/obo/>
+PREFIX ccp: <http://ccp.ucdenver.edu/obo/ext/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX bp: <http://www.biopax.org/release/biopax-level3.owl#>
+PREFIX bp3: <http://www.reactome.org/biopax/63/48887#>
+SELECT ?bcr_record ?stoi_coeff ?stoi ?right_record 
+WHERE {
+?bcr rdf:type bp:BiochemicalReaction .
+?bcr bp:participantStoichiometry ?stoi .
+?stoi bp:physicalEntity ?right .
+?bcr bp:right ?right .
+?stoi bp:stoichiometricCoefficient ?stoi_coeff .
+GRAPH <file://add_biochemical_reaction_records_and_reactome_ids_from_human_reactome_to_ice_step_a.nt> {
+?bcr obo:IAO_0000142 ?bcr_record .
+}
+?right obo:IAO_0000142 ?right_record .
+GRAPH <file://add_biochemical_reaction_record_outputs_from_human_reactome_to_ice_step_f2.nt> {
+?bcr_record obo:BFO_0000051 ?right_record .
+?right_record rdf:type ccp:IAO_EXT_0001550 .
+}
+}"
+}


### PR DESCRIPTION
…from BioPAX to ICE; each rule requires information from previous rounds.
step 2: 
add_biochemical_reaction_record_inputs_from_human_reactome_to_ice_step_f1.clj
add_biochemical_reaction_record_outputs_from_human_reactome_to_ice_step_f2.clj
add_complex_record_component_stoichiometries_from_human_reactome_to_ice_step_e.clj
step 3: 
add_biochemical_reaction_record_input_stoichiometries_from_human_reactome_to_ice_step_g1.clj
add_biochemical_reaction_record_output_stoichiometries_from_human_reactome_to_ice_step_g2.clj
Note to self: added backticks and changed sparql-string to body.  That won't run in jupyter, but I hope it behaves for the build.